### PR TITLE
Fix missing MUC cachedef strings

### DIFF
--- a/lang/en/format_socialwall.php
+++ b/lang/en/format_socialwall.php
@@ -149,3 +149,7 @@ $string['unknownuser'] = 'Unknown user';
 $string['uploadafile'] = 'Upload a file';
 $string['unlockpost'] = 'Post is locked, click to unlock';
 $string['writecomment'] = 'Write a comment';
+$string['cachedef_postformparams'] = 'SocialWall:Post form params';
+$string['cachedef_postformerrors'] = 'SocialWall:Post form errors';
+$string['cachedef_timelinefilter'] = 'SocialWall:Timeline filter';
+$string['cachedef_commentformerrors'] = 'SocialWall:Comment form errors';


### PR DESCRIPTION
Please see if you can added those missing MUC cachedef strings.
(and maybe change them, if they are not correctly reflect the actions. since I was guessing)
