### PR TITLE
this duplicated element were setting numsections to 0

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -194,10 +194,6 @@ class format_socialwall extends format_topics {
                     'help' => 'deletemodspermanently',
                     'help_component' => 'format_socialwall'
                 ),
-                'numsections' => array(
-                    'label' => '',
-                    'element_type' => 'hidden'
-                )
             );
             $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);
         }


### PR DESCRIPTION
Hello,

this was causing the numsections to 0 sometimes, so one had to first save a course with at least three sections in other format and then get back to the socialwall format to get it working.
The numsections is first  defined at https://github.com/danielneis/moodle-format_socialwall/blob/e6e702d98bd364efbd06ca5e80175176be43a635/lib.php#L125

Kind regards,
Daniel
